### PR TITLE
Removed the exec from _updateMapper function

### DIFF
--- a/crud.controller.js
+++ b/crud.controller.js
@@ -743,7 +743,7 @@ CrudController.prototype = {
                         resolve({ status: 200, data: updated });
                     });
                 }
-            }).exec();
+            });
         });
     },
     _bulkUpdate: function (req, res) {


### PR DESCRIPTION
Removed the exec from _updateMapper function which was causing the query to run twice and it is not required as it is using the callback function. This _updateMapper function is used in Bulk Update function of crudder. 