### PR TITLE
HDFC life Mongo Upgrade changes

### DIFF
--- a/crud.controller.js
+++ b/crud.controller.js
@@ -363,7 +363,7 @@ CrudController.prototype = {
             filter['_metadata.deleted'] = false;
         return this.model
             .find(filter)
-            .count()
+            .countDocuments()
             .exec()
             .then(result => self.Okay(res, result))
             .catch(err => {
@@ -432,10 +432,10 @@ CrudController.prototype = {
                 docs = documents;
                 let promise = Promise.resolve();
                 if (metadata) {
-                    promise = this.model.count(filter)
+                    promise = this.model.countDocuments(filter)
                         .then(_c => {
                             matched = _c;
-                            return this.model.count()
+                            return this.model.countDocuments()
                         })
                         .then(_t => {
                             totalCount = _t;

--- a/crud.controller.js
+++ b/crud.controller.js
@@ -117,7 +117,7 @@ function removeDocument(doc, req, type) {
                 })
                 .catch(err => resolve(null));
         } else {
-            doc.remove(req)
+            doc.deleteOne(req)
                 .then(() => {
                     resolve(doc.toObject());
                 })
@@ -895,7 +895,7 @@ CrudController.prototype = {
                     return;
                 }
                 document = doc;
-                return doc.remove(req);
+                return doc.deleteOne(req);
             })
             .then(() => {
                 var logObject = {

--- a/crud.controller.js
+++ b/crud.controller.js
@@ -895,6 +895,11 @@ CrudController.prototype = {
                     return;
                 }
                 document = doc;
+                // Set explicitly so deleteOne hooks can rely on this._req for
+                // the genuine request object; Mongoose does not reliably
+                // forward the argument passed to deleteOne() to hooks in the
+                // same shape (unlike the removed remove() method).
+                document._req = req;
                 return doc.deleteOne(req);
             })
             .then(() => {

--- a/index.js
+++ b/index.js
@@ -135,11 +135,29 @@ function injectDefaults(schema) {
         if (this._metadata) {
             if (this._metadata.version) this._metadata.version.document++;
             this._metadata.lastUpdated = new Date();
-            // if (this.isNew) {
-            //     this._metadata.createdAt = new Date();
-            // }
         }
         next();
+    });
+    schema.post('save', function (doc) {
+        // Fix Mongoose 8 bug: regenerate subdocument _id with id:undefined after save
+        const visited = new Set();
+        const fixIds = (obj) => {
+            if (!obj || typeof obj !== 'object') return;
+            if (visited.has(obj)) return;
+            visited.add(obj);
+            const keys = Array.isArray(obj) ? obj.map((_, i) => i) : Object.keys(obj);
+            keys.forEach(k => {
+                try {
+                    const v = obj[k];
+                    if (v && v._bsontype === 'ObjectId' && !v.id) {
+                        obj[k] = new mongoose.Types.ObjectId();
+                    } else if (v && typeof v === 'object') {
+                        fixIds(v);
+                    }
+                } catch(e) {}
+            });
+        };
+        if (doc && doc._doc) fixIds(doc._doc);
     });
     schema.pre('update', function (next) {
         if (this._metadata) {

--- a/package.json
+++ b/package.json
@@ -14,9 +14,6 @@
   ],
   "author": "Jerry M. <jerry@appveen.com>",
   "license": "MIT",
-  "peerDependencies": {
-    "mongoose": ">=6.0.0"
-  },
   "dependencies": {
     "lodash": "^4.17.21",
     "log4js": "^6.6.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appveen/swagger-mongoose-crud",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Swagger Mongoose crud wrapper",
   "main": "index.js",
   "scripts": {
@@ -14,6 +14,9 @@
   ],
   "author": "Jerry M. <jerry@appveen.com>",
   "license": "MIT",
+  "peerDependencies": {
+    "mongoose": ">=6.0.0"
+  },
   "dependencies": {
     "lodash": "^4.17.21",
     "log4js": "^6.6.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appveen/swagger-mongoose-crud",
-  "version": "2.0.2",
+  "version": "2.8.0",
   "description": "Swagger Mongoose crud wrapper",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Last 5 commits on swagger-mongoose-crud (main), all part of the Mongoose 8.x migration:

1. 9469d44 (Jul 3) — Set document._req before deleteOne() so document-hooks get the real request instead of Mongoose's internal self argument (fixed the "Cannot read properties of undefined (reading 'length')" app-deletion crash).
2. 38baaa6 (Jul 2) — Replaced doc.remove() with doc.deleteOne() — .remove() was removed in Mongoose 7+, causing TypeError: doc.remove is not a function.
3. e8cee62 (Jun 18) — Fixed post-save hook to regenerate corrupted subdocument ObjectIds under Mongoose 8.
4. fd5a798 (Jun 16) — Removed the mongoose peerDependencies entry (no longer needed/was causing install conflicts).
5. 7395a84 (Jun 9) — Replaced deprecated .count() with .countDocuments() for Mongoose 8.x compatibility.

All five are compatibility fixes for the same underlying Mongoose 8.x/MongoDB driver v6 upgrade 